### PR TITLE
Need to be able to pass in the anti-focus option

### DIFF
--- a/src/vc-recaptcha.js
+++ b/src/vc-recaptcha.js
@@ -15,9 +15,9 @@
                     conf
                 );
             },
-            reload: function (t) {
+            reload: function (should_focus) {
                 // $log.info('Reloading captcha');
-                Recaptcha.reload(t);
+                Recaptcha.reload(should_focus && 't');
 
                 // Since the previous call is asynch, we need again the same hack. See directive code.
                 $timeout(callback, 1000);


### PR DESCRIPTION
Captcha is stealing focus on reload. Adding a 't' as the first parameter tells it to not steal focus.
https://groups.google.com/forum/#!topic/recaptcha/HYg5OYJU-uQ

Usage: `vcRecaptchaService.reload('t');`
