### PR TITLE
Resolve promise if `grecaptcha` already exists

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -31,6 +31,12 @@
             }
         }
 
+
+        // Check if grecaptcha is not defined already.
+        if (ng.isDefined($window.grecaptcha)) {
+            $window.vcRecapthaApiLoaded();
+        }
+
         return {
 
             /**


### PR DESCRIPTION
Fix recaptcha not loading if it’s included in a secondary view when using ng-route.

Fixes #24 
