### PR TITLE
Feat(validation): Added validation if within ngForm. + Slight clean-up.

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -8,16 +8,20 @@
 
     var app = ng.module('vcRecaptcha');
 
-    app.directive('vcRecaptcha', ['$log', '$timeout', 'vcRecaptchaService', function ($log, $timeout, vcRecaptcha) {
+    app.directive('vcRecaptcha', ['$timeout', 'vcRecaptchaService', function ($timeout, vcRecaptcha) {
 
         return {
             restrict: 'A',
+            require: "?^^form",
             scope: {
+                response: '=?ngModel',
                 key: '=',
+                theme: '?=',
                 onCreate: '&',
-                onSuccess: '&'
+                onSuccess: '&',
+                onExpire: '&'
             },
-            link: function (scope, elm, attrs) {
+            link: function (scope, elm, attrs, ctrl) {
                 if (!attrs.hasOwnProperty('key')) {
                     throwNoKeyException();
                 }
@@ -33,20 +37,39 @@
                         throwNoKeyException();
                     }
 
-                    var callback = function () {
-                        // Notify about the response availability
-                        scope.onSuccess({response: vcRecaptcha.getResponse(scope.widgetId)});
+                    var callback = function (gRecaptchaResponse) {
+                        // Safe $apply
+                        $timeout(function () {
+                            if(ctrl){
+                                ctrl.$setValidity('recaptcha',true);
+                            }
+                            scope.response = gRecaptchaResponse;
+                            // Notify about the response availability
+                            scope.onSuccess({response: gRecaptchaResponse, widgetId: scope.widgetId});
+                        });
+
+                        // captcha session lasts 2 mins after set.
+                        $timeout(function (){
+                            if(ctrl){
+                                ctrl.$setValidity('recaptcha',false);
+                            }
+                            scope.response = "";
+                            // Notify about the response availability
+                            scope.onExpire({widgetId: scope.widgetId});
+                        }, 2 * 60 * 1000);
                     };
 
-                    vcRecaptcha.create(elm[0], scope.key, callback, {
+                    vcRecaptcha.create(elm[0], key, callback, {
 
-                        theme: attrs.theme || null
+                        theme: scope.theme || attrs.theme || null
 
                     }).then(function (widgetId) {
-
                         // The widget has been created
+                        if(ctrl){
+                            ctrl.$setValidity('recaptcha',false);
+                        }
                         scope.widgetId = widgetId;
-                        scope.onCreate({widgetId: scope.widgetId});
+                        scope.onCreate({widgetId: widgetId});
                     });
 
                     // Remove this listener to avoid creating the widget more than once.

--- a/src/service.js
+++ b/src/service.js
@@ -7,7 +7,7 @@
     /**
      * An angular service to wrap the reCaptcha API
      */
-    app.service('vcRecaptchaService', ['$timeout', '$window', '$q', function ($timeout, $window, $q) {
+    app.service('vcRecaptchaService', ['$window', '$q', function ($window, $q) {
         var deferred = $q.defer(), promise = deferred.promise, recaptcha;
 
         $window.vcRecapthaApiLoaded = function () {


### PR DESCRIPTION
#29 If the directive is within a named form or ngForm (has the form controller) it will now set validation on that form depending on if the box is checked or not. Using standard form validation can help prevent bad submissions.

#28 onExpire will be fired when the captcha's session expires (from testing, it was always two minutes, thus a two minute timeout).

#27 ngModel will now be populated with the response value if it is on the element (And it will become "" when the session expires (mimicking the hidden textarea that is injected by recaptcha (use recaptcha for full page form submissions)))

\+ WidgetId is now accessible in the onSuccess callback
\+ Slight clean up of unused injections