### PR TITLE
rename in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "vc-angular-recaptcha",
+    "name": "angular-recaptcha",
     "version": "2.1.1",
     "keywords": ["angular", "captcha", "recaptcha", "vividcortex", "human", "form", "validation", "signup", "security", "login"],
     "main": "release/angular-recaptcha.js",


### PR DESCRIPTION
The module is registered to Bower as "angular-recaptcha", but the {{bower.json}} had name of {{vc-angular-recaptcha". This fixes that. If you prefer to register to Bower as "vc-angular-recaptcha" instead or as well, that is also an option.
