### PR TITLE
Fix(directive): remove jquery dep

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -46,7 +46,7 @@
                             scope.response = gRecaptchaResponse;
                             // Notify about the response availability
                             scope.onSuccess({response: gRecaptchaResponse, widgetId: scope.widgetId});
-                            angular.element('.pls-container').parent().remove();
+                            cleanup();
                         });
 
                         // captcha session lasts 2 mins after set.
@@ -71,16 +71,19 @@
                         }
                         scope.widgetId = widgetId;
                         scope.onCreate({widgetId: widgetId});
-                        
-                        scope.$on('$destroy', function(){
-                            angular.element('.pls-container').parent().remove();
-                        });
-                        
+
+                        scope.$on('$destroy', cleanup);
+
                     });
 
                     // Remove this listener to avoid creating the widget more than once.
                     removeCreationListener();
                 });
+
+                function cleanup(){
+                  // removes elements reCaptcha added.
+                  angular.element(document.querySelectorAll('.pls-container')).parent().remove();
+                }
             }
         };
     }]);


### PR DESCRIPTION
There was a dependency on jQuery that was accidentally added.  This removes the dependency by utilizing native browser `document.querySelectorAll()`.

This also DRYs up that call by moving it to a function that can be called where needed.