### PR TITLE
querySelectorAll is available in document but not in $document

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -82,7 +82,7 @@
 
                 function cleanup(){
                   // removes elements reCaptcha added.
-                  angular.element($document.querySelectorAll('.pls-container')).parent().remove();
+                  angular.element($document[0].querySelectorAll('.pls-container')).parent().remove();
                 }
             }
         };


### PR DESCRIPTION
Hey guys, not sure why that line was written that way, here’s how i think it could be improved.

querySelectorAll is not available in $document.

Closes #54 