### PR TITLE
Tidy up the validity state on $destroy.

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -29,6 +29,7 @@
 
                 scope.widgetId = null;
 
+                var sessionTimeout;
                 var removeCreationListener = scope.$watch('key', function (key) {
                     if (!key) {
                         return;
@@ -51,7 +52,7 @@
                         });
 
                         // captcha session lasts 2 mins after set.
-                        $timeout(function (){
+                        sessionTimeout = $timeout(function (){
                             if(ctrl){
                                 ctrl.$setValidity('recaptcha',false);
                             }
@@ -74,13 +75,26 @@
                         scope.widgetId = widgetId;
                         scope.onCreate({widgetId: widgetId});
 
-                        scope.$on('$destroy', cleanup);
+                        scope.$on('$destroy', destroy);
 
                     });
 
                     // Remove this listener to avoid creating the widget more than once.
                     removeCreationListener();
                 });
+
+                function destroy() {
+                  if (ctrl) {
+                    // reset the validity of the form if we were removed
+                    ctrl.$setValidity('recaptcha', null);
+                  }
+                  if (sessionTimeout) {
+                    // don't trigger the session timeout if we are no longer active
+                    $timeout.cancel(sessionTimeout);
+                    sessionTimeout = null;
+                  }
+                  cleanup();
+                }
 
                 function cleanup(){
                   // removes elements reCaptcha added.


### PR DESCRIPTION
When the directive is removed/destroyed, as would be the case when using an `ng-if,` then this PR makes sure that any enclosing forms validity is reset to a state as if the directive was never included.

Specifically we remove the validity record and stop the session timeout from completing (which would have forced the validity to false after 2 mins).