### PR TITLE
Remove cleanup after creating the captcha element

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -47,7 +47,6 @@
                             scope.response = gRecaptchaResponse;
                             // Notify about the response availability
                             scope.onSuccess({response: gRecaptchaResponse, widgetId: scope.widgetId});
-                            cleanup();
                         });
 
                         // captcha session lasts 2 mins after set.


### PR DESCRIPTION
This fixes a security error after reloading the captcha.

```
Uncaught SecurityError: Blocked a frame with origin "https://www.google.com" from accessing a frame with origin "https://xxx.com". Protocols, domains, and ports must match.
```

Fixes #62, fixes #63

