### PR TITLE
Add required to opt out of validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ var app = angular.module('myApp', ['vcRecaptcha']);
 
 Here, the `key` attribute is passed to the directive's scope, so you can use either a property in your scope or just a hardcoded string. Be careful to use your public key, not your private one.
 
+Form Validation
+---------------
+**By default**, if placed in a [form](https://docs.angularjs.org/api/ng/directive/form) using [formControl](https://docs.angularjs.org/api/ng/type/form.FormController) the captcha will need to be checked for the form to be valid.
+If the captcha is not checked (if the user has not checked the box or the check has expired) the form will be marked as invalid. The validation key is `recaptcha`.
+You can **opt out** of this feature by setting the `required` attribute to `false` or a scoped variable 
+that will evaluate to `false`. Any other value, or omitting the attribute will opt in to this feature.
+
 Response Validation
 -------------------
 

--- a/src/directive.js
+++ b/src/directive.js
@@ -31,7 +31,6 @@
 
                 scope.widgetId = null;
 
-                var sessionTimeout;
                 var removeCreationListener = scope.$watch('key', function (key) {
                     if (!key) {
                         return;
@@ -51,16 +50,6 @@
                             // Notify about the response availability
                             scope.onSuccess({response: gRecaptchaResponse, widgetId: scope.widgetId});
                         });
-
-                        // captcha session lasts 2 mins after set.
-                        sessionTimeout = $timeout(function (){
-                            if(ctrl){
-                                ctrl.$setValidity('recaptcha',false);
-                            }
-                            scope.response = "";
-                            // Notify about the response availability
-                            scope.onExpire({widgetId: scope.widgetId});
-                        }, 2 * 60 * 1000);
                     };
 
                     vcRecaptcha.create(elm[0], key, callback, {
@@ -68,7 +57,8 @@
                         stoken: scope.stoken || attrs.stoken || null,
                         theme: scope.theme || attrs.theme || null,
                         tabindex: scope.tabindex || attrs.tabindex || null,
-                        size: scope.size || attrs.size || null
+                        size: scope.size || attrs.size || null,
+                        'expired-callback': expired
 
                     }).then(function (widgetId) {
                         // The widget has been created
@@ -91,12 +81,17 @@
                     // reset the validity of the form if we were removed
                     ctrl.$setValidity('recaptcha', null);
                   }
-                  if (sessionTimeout) {
-                    // don't trigger the session timeout if we are no longer active
-                    $timeout.cancel(sessionTimeout);
-                    sessionTimeout = null;
-                  }
+
                   cleanup();
+                }
+
+                function expired(){
+                    if(ctrl){
+                        ctrl.$setValidity('recaptcha',false);
+                    }
+                    scope.response = "";
+                    // Notify about the response availability
+                    scope.onExpire({widgetId: scope.widgetId});
                 }
 
                 function cleanup(){

--- a/src/directive.js
+++ b/src/directive.js
@@ -20,6 +20,7 @@
                 theme: '=?',
                 size: '=?',
                 tabindex: '=?',
+                required: '=?',
                 onCreate: '&',
                 onSuccess: '&',
                 onExpire: '&'
@@ -30,6 +31,10 @@
                 }
 
                 scope.widgetId = null;
+
+                if(ctrl && angular.isDefined(attrs.required)){
+                    scope.$watch('required', validate);
+                }
 
                 var removeCreationListener = scope.$watch('key', function (key) {
                     if (!key) {
@@ -43,10 +48,9 @@
                     var callback = function (gRecaptchaResponse) {
                         // Safe $apply
                         $timeout(function () {
-                            if(ctrl){
-                                ctrl.$setValidity('recaptcha',true);
-                            }
                             scope.response = gRecaptchaResponse;
+                            validate();
+
                             // Notify about the response availability
                             scope.onSuccess({response: gRecaptchaResponse, widgetId: scope.widgetId});
                         });
@@ -62,9 +66,7 @@
 
                     }).then(function (widgetId) {
                         // The widget has been created
-                        if(ctrl){
-                            ctrl.$setValidity('recaptcha',false);
-                        }
+                        validate();
                         scope.widgetId = widgetId;
                         scope.onCreate({widgetId: widgetId});
 
@@ -86,12 +88,17 @@
                 }
 
                 function expired(){
-                    if(ctrl){
-                        ctrl.$setValidity('recaptcha',false);
-                    }
                     scope.response = "";
+                    validate();
+
                     // Notify about the response availability
                     scope.onExpire({widgetId: scope.widgetId});
+                }
+
+                function validate(){
+                    if(ctrl){
+                        ctrl.$setValidity('recaptcha', scope.required === false ? null : Boolean(scope.response));
+                    }
                 }
 
                 function cleanup(){


### PR DESCRIPTION
Resolves #96 by adding and documenting the required attribute.
When require is `false` or is a scoped variable which is `false`,
the form validation will be removed.
This is opt out to prevent a breaking change and usually the validation is
preferred.

This change also includes the changes to use the recaptcha expired callback as they would have conflicted if made separately.