### PR TITLE
Add type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can optionally pass a __theme__ the captcha should use, as an html attribute
         vc-recaptcha
         theme="---- light or dark ----"
         size="---- compact or normal ----"
+        type="'---- audio or image ----'"
         key="'---- YOUR PUBLIC KEY GOES HERE ----'"
     ></div>
 ```

--- a/src/directive.js
+++ b/src/directive.js
@@ -19,6 +19,7 @@
                 stoken: '=?',
                 theme: '=?',
                 size: '=?',
+                type: '=?',
                 tabindex: '=?',
                 onCreate: '&',
                 onSuccess: '&',
@@ -67,6 +68,7 @@
 
                         stoken: scope.stoken || attrs.stoken || null,
                         theme: scope.theme || attrs.theme || null,
+                        type: scope.type || attrs.type || null,
                         tabindex: scope.tabindex || attrs.tabindex || null,
                         size: scope.size || attrs.size || null
 


### PR DESCRIPTION
Adds type support through the type attribute, which just gets passed to
reCaptcha.  Possible values are `'audio'` and `'image'` (per reCaptcha
docs). README was also update to show this attribute.