### PR TITLE
Add ability to set onload function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ See [the demo file](demo/usage.html) for a quick usage example.
   async defer
 ></script>
 ```
-    As you can see, we are specifying a `onload` callback, which will notify the
-    angular service once the api is ready for usage.
+
+As you can see, we are specifying a `onload` callback, which will notify the angular service once the api is ready for usage.
+
+The `onload` callback name defaults to `vcRecaptchaApiLoaded`, but can be overridden by the service provider via `vcRecaptchaServiceProvider.setOnLoadFunctionName('myOtherFunctionName');`.
 
 - Also include the vc-recaptcha script and make your angular app depend on the `vcRecaptcha` module.
 

--- a/src/service.js
+++ b/src/service.js
@@ -14,6 +14,7 @@
     app.provider('vcRecaptchaService', function(){
         var provider = this;
         var config = {};
+        provider.onLoadFunctionName = 'vcRecaptchaApiLoaded';
 
         /**
          * Sets the reCaptcha configuration values which will be used by default is not specified in a specific directive instance.
@@ -75,6 +76,16 @@
             config.type = type;
         };
 
+        /**
+         * Sets the reCaptcha configuration values which will be used by default is not specified in a specific directive instance.
+         *
+         * @since 2.5.0
+         * @param onLoadFunctionName  string name which overrides the name of the onload function. Should match what is in the recaptcha script querystring onload value.
+         */
+        provider.setOnLoadFunctionName = function(onLoadFunctionName){
+            provider.onLoadFunctionName = onLoadFunctionName;
+        };
+
         provider.$get = ['$window', '$q', function ($window, $q) {
             var deferred = $q.defer(), promise = deferred.promise, recaptcha;
 
@@ -88,7 +99,7 @@
 
             $window.vcRecaptchaApiLoadedCallback.push(callback);
 
-            $window.vcRecaptchaApiLoaded = function () {
+            $window[provider.onLoadFunctionName] = function () {
                 $window.vcRecaptchaApiLoadedCallback.forEach(function(callback) {
                     callback();
                 });


### PR DESCRIPTION
Resolves #25 by adding the ability to set the name of the function that is
used as the onload callback.
Also added documentation.

_This commit is on top of the commit which adds the service provider as the
service provider is needed for this to work._