### PR TITLE
Reset directive validation when reCaptcha is reset

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -61,7 +61,7 @@
                         scope.$on('$destroy', destroy);
 
                         scope.$on('reCaptchaReset', function(resetWidgetId){
-                          if(widgetId === resetWidgetId){
+                          if(angular.isUndefined(resetWidgetId) || widgetId === resetWidgetId){
                             scope.response = "";
                             validate();
                           }

--- a/src/directive.js
+++ b/src/directive.js
@@ -60,6 +60,13 @@
 
                         scope.$on('$destroy', destroy);
 
+                        scope.$on('reCaptchaReset', function(resetWidgetId){
+                          if(widgetId === resetWidgetId){
+                            scope.response = "";
+                            validate();
+                          }
+                        })
+
                     });
 
                     // Remove this listener to avoid creating the widget more than once.

--- a/src/service.js
+++ b/src/service.js
@@ -75,7 +75,7 @@
             config.type = type;
         };
 
-        provider.$get = ['$window', '$q', function ($window, $q) {
+        provider.$get = ['$rootScope','$window', '$q', function ($rootScope, $window, $q) {
             var deferred = $q.defer(), promise = deferred.promise, recaptcha;
 
             $window.vcRecaptchaApiLoadedCallback = $window.vcRecaptchaApiLoadedCallback || [];
@@ -113,6 +113,32 @@
             // Check if grecaptcha is not defined already.
             if (ng.isDefined($window.grecaptcha)) {
                 callback();
+            },
+
+            /**
+             * Reloads the reCaptcha
+             */
+            reload: function (widgetId) {
+                validateRecaptchaInstance();
+
+                // $log.info('Reloading captcha');
+                recaptcha.reset(widgetId);
+
+                // Let everyone know this widget has been reset.
+                $rootScope.$broadcast('reCaptchaReset', widgetId);
+            },
+
+            /**
+             * Gets the response from the reCaptcha widget.
+             *
+             * @see https://developers.google.com/recaptcha/docs/display#js_api
+             *
+             * @returns {String}
+             */
+            getResponse: function (widgetId) {
+                validateRecaptchaInstance();
+
+                return recaptcha.getResponse(widgetId);
             }
 
             return {


### PR DESCRIPTION
Resolves #69 and #111. When the service triggers a reset, the directive associated with the
widgetid being reset will clear the response on the model and mark the
element as invalid (if validation is enabled).

This uses pub/sub to allow the service to notify the directive of the reset. There are several other ways to do this but this was more simple.