### PR TITLE
Fix #124

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -83,11 +83,14 @@
                 }
 
                 function expired(){
-                    scope.response = "";
-                    validate();
+                    // Safe $apply
+                    $timeout(function () {
+                        scope.response = "";
+                        validate();
 
-                    // Notify about the response availability
-                    scope.onExpire({widgetId: scope.widgetId});
+                        // Notify about the response availability
+                        scope.onExpire({ widgetId: scope.widgetId });
+                    });
                 }
 
                 function validate(){


### PR DESCRIPTION
Make the expired callback handler trigger a digest using `$timeout` as a safe apply.