### PR TITLE
Make it easier to preserve license after minification

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,9 +5,9 @@ module.exports = function (grunt) {
         pkg: grunt.file.readJSON('package.json'),
         meta: {
             banner: '/**\n' +
-                ' * <%= pkg.name %> build:<%= grunt.template.today("yyyy-mm-dd") %> \n' +
-                ' * <%= pkg.homepage %> \n' +
-                ' * Copyright (c) <%= grunt.template.today("yyyy") %> VividCortex \n' +
+                ' * <%= pkg.name %> build:<%= grunt.template.today("yyyy-mm-dd") %>\n' +
+                ' * <%= pkg.homepage %>\n' +
+                ' * Copyright (c) <%= grunt.template.today("yyyy") %> VividCortex\n' +
                 '**/\n\n'
         },
         concat: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function (grunt) {
         pkg: grunt.file.readJSON('package.json'),
         meta: {
             banner: '/**\n' +
-                ' * <%= pkg.name %> build:<%= grunt.template.today("yyyy-mm-dd") %>\n' +
+                ' * @license <%= pkg.name %> build:<%= grunt.template.today("yyyy-mm-dd") %>\n' +
                 ' * <%= pkg.homepage %>\n' +
                 ' * Copyright (c) <%= grunt.template.today("yyyy") %> VividCortex\n' +
                 '**/\n\n'


### PR DESCRIPTION
Minifiers like [uglifyjs](https://github.com/mishoo/UglifyJS2#keeping-copyright-notices-or-other-comments) and [closure compiler](https://developers.google.com/closure/compiler/docs/js-for-compiler#tag-license) interpret the `@license` tag and preserve the license in the minified output. This makes it easier to comply with the MIT license (and most others) which requires:

> The above copyright notice and this permission notice shall be
> included in all copies or substantial portions of the Software.