### PR TITLE
Not required by default and when undefined equivalent to false

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -25,7 +25,7 @@
             link: function (scope, elm, attrs, ctrl) {
                 scope.widgetId = null;
 
-                if(ctrl && ng.isDefined(attrs.required)){
+                if(ctrl){
                     scope.$watch('required', validate);
                 }
 
@@ -95,7 +95,7 @@
 
                 function validate(){
                     if(ctrl){
-                        ctrl.$setValidity('recaptcha', scope.required === false ? null : Boolean(scope.response));
+                        ctrl.$setValidity('recaptcha', !scope.required ? null : Boolean(scope.response));
                     }
                 }
 

--- a/tests/directive_test.js
+++ b/tests/directive_test.js
@@ -82,7 +82,7 @@ describe('directive: vcRecaptcha', function () {
             var element     = angular.element(
                     '<form name="form">' +
                     '<input type="text" ng-model="something" />' +
-                    '<div vc-recaptcha key="key" on-create="onCreate({widgetId: widgetId})" />' +
+                    '<div vc-recaptcha key="key" required="true" on-create="onCreate({widgetId: widgetId})" />' +
                     '</form>'
                 ),
 
@@ -134,7 +134,7 @@ describe('directive: vcRecaptcha', function () {
         it('should change the validation to false - session expired', function () {
             var element     = angular.element('<form name="form">' +
                     '<input type="text" ng-model="something" />' +
-                    '<div vc-recaptcha key="k" on-create="onCreate()" on-success="onSuccess()"/>' +
+                    '<div vc-recaptcha required="true" key="k" on-create="onCreate()" on-success="onSuccess()"/>' +
                     '</form>'),
 
                 _fakeCreate = function (element, config) {


### PR DESCRIPTION
Great project! Thanks for your work. I'd like to make a contribution.

I've run into a problem where the recaptcha should initially **not** be required; and then change to required when certain conditions are met. (Number of invalid logins)

There were two problems:
- Without the `required` attribute being set; the directive does not set a watch on the `required` attribute and thus when it changes the control is not revalidated. This also impacts use of `ng-required` since it does not match for the `required` attribute. That is; it did not seem possible to initialise as not required; and transition to required.
- When no required attribute is provided; `scope.required` evaluates to undefined; which sets the validity to `Boolean(scope.response)`

This PR modifies the directive so that it is **not required** by default, and needs the required attribute adding in order to make it required. `ng-required` will then function as expected.

I can see why it might be nice to have a recaptcha required by default; and this is definitely a change in the behaviour. But it is consistent with other fields.
