### PR TITLE
Added missing tabindex option when creating recaptcha.

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -142,6 +142,7 @@
                     conf.stoken = conf.stoken || config.stoken;
                     conf.size = conf.size || config.size;
                     conf.type = conf.type || config.type;
+                    conf.tabindex = conf.tabindex || config.tabindex;
 
                     if (!conf.sitekey || conf.sitekey.length !== 40) {
                         throwNoKeyException();


### PR DESCRIPTION
The tabindex option was not being passed into the recaptcha render function.

Tabindex doesn't seem to work as a whole, even with the plain javascript tag provided by Google, so this doesn't really fix tabindex working per se, but this line was missing and needed to be added in case Google ever fixes the tabindex not working.