### PR TITLE
chore(coverage): report coverage on CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_script:
 
 script:
   - grunt karma:ci
+
+after_script:
+  - grunt coverage


### PR DESCRIPTION
I noticed the coverage badge in the README and that a grunt coverage task was set up... this just tell travis to report the coverage after it runs the tests.