### PR TITLE
Improvement: Generate recaptcha script on demand. closes #175

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,7 @@ See [the demo file](demo/usage.html) for a quick usage example.
 
 - First, you need to get a valid recaptcha key for your domain. Go to http://www.google.com/recaptcha.
 
-- Include the reCaptcha [API](https://developers.google.com/recaptcha/docs/display#AJAX) using this script in your HTML:
-
-```html
-<script
-  src="https://www.google.com/recaptcha/api.js?onload=vcRecaptchaApiLoaded&render=explicit"
-  async defer
-></script>
-```
-
-As you can see, we are specifying a `onload` callback, which will notify the angular service once the api is ready for usage.
-
-The `onload` callback name defaults to `vcRecaptchaApiLoaded`, but can be overridden by the service provider via `vcRecaptchaServiceProvider.setOnLoadFunctionName('myOtherFunctionName');`.
-
-- Also include the vc-recaptcha script and make your angular app depend on the `vcRecaptcha` module.
+- Include the vc-recaptcha script and make your angular app depend on the `vcRecaptcha` module.
 
 ```html
 <script type="text/javascript" src="angular-recaptcha.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,6 +23,7 @@ module.exports = function (config) {
             'src/module.js',
             'src/*.js',
 
+            'tests/*.driver.js',
             'tests/*_test.js'
         ],
 

--- a/src/service.js
+++ b/src/service.js
@@ -95,7 +95,7 @@
             provider.onLoadFunctionName = onLoadFunctionName;
         };
 
-        provider.$get = ['$rootScope','$window', '$q', function ($rootScope, $window, $q) {
+        provider.$get = ['$rootScope','$window', '$q', '$document', function ($rootScope, $window, $q, $document) {
             var deferred = $q.defer(), promise = deferred.promise, instances = {}, recaptcha;
 
             $window.vcRecaptchaApiLoadedCallback = $window.vcRecaptchaApiLoadedCallback || [];
@@ -133,6 +133,13 @@
             // Check if grecaptcha is not defined already.
             if (ng.isDefined($window.grecaptcha)) {
                 callback();
+            } else {
+                // Generate link on demand
+                var script = $document.get(0).createElement('script');
+                script.async = true;
+                script.defer = true;
+                script.src = 'https://www.google.com/recaptcha/api.js?onload='+provider.onLoadFunctionName+'&render=explicit';
+                $document.get(0).body.appendChild(script);
             }
 
             return {

--- a/tests/provider.driver.js
+++ b/tests/provider.driver.js
@@ -1,0 +1,35 @@
+function ProviderDriver() {
+    var _this = this;
+    var mockModules = {
+        $window: {}
+    };
+
+    module(mockModules); // mock all the properties
+
+    this.given = {
+        recaptchaLoaded: function (recaptchaMock) {
+            mockModules.$window.grecaptcha = recaptchaMock;
+            return _this;
+        }
+    };
+
+    this.when = {
+        created: function () {
+            module(function (vcRecaptchaServiceProvider) {
+                _this.provider = vcRecaptchaServiceProvider;
+            });
+
+            inject(); // needed for angular-mocks to kick off
+
+            return _this;
+        },
+        callingCreate: function () {
+            inject(function (vcRecaptchaService, $rootScope) {
+                vcRecaptchaService.create(null, {});
+                $rootScope.$digest();
+            });
+
+            return this;
+        }
+    };
+}

--- a/tests/provider_test.js
+++ b/tests/provider_test.js
@@ -1,0 +1,94 @@
+describe('provider', function () {
+    'use strict';
+
+    var driver,
+        recaptchaMock,
+        key;
+
+    beforeEach(module('vcRecaptcha'));
+
+    beforeEach(function () {
+        driver = new ProviderDriver();
+        driver.given.recaptchaLoaded(recaptchaMock = jasmine.createSpyObj('recaptchaMock', ['render']))
+            .when.created();
+
+        driver.provider.setSiteKey(key = '1234567890123456789012345678901234567890');
+    });
+
+    it('should setDefaults', function () {
+        var modifiedKey = key.substring(0, 39) + 'x';
+
+        driver.provider.setDefaults({key: modifiedKey});
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({sitekey: modifiedKey}));
+    });
+
+    it('should setSiteKey', function () {
+        driver.provider.setSiteKey(key);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({sitekey: key}));
+    });
+
+    it('should setTheme', function () {
+        var theme = 'theme';
+        driver.provider.setTheme(theme);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({theme: theme}));
+    });
+
+    it('should setStoken', function () {
+        var stoken = 'stoken';
+        driver.provider.setStoken(stoken);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({stoken: stoken}));
+    });
+
+    it('should setSize', function () {
+        var size = 'size';
+        driver.provider.setSize(size);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({size: size}));
+    });
+
+    it('should setType', function () {
+        var type = 'type';
+        driver.provider.setType(type);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({type: type}));
+    });
+
+    it('should setLang', function () {
+        var lang = 'en';
+        driver.provider.setLang(lang);
+
+        driver.when.callingCreate();
+
+        var callArgs = recaptchaMock.render.calls.mostRecent().args[1];
+
+        expect(callArgs).toEqual(jasmine.objectContaining({hl: lang}));
+    });
+});

--- a/tests/service.driver.js
+++ b/tests/service.driver.js
@@ -1,0 +1,46 @@
+function ServiceDriver() {
+    var _this = this;
+    var mockModules = {
+        $window: {},
+        $document: {}
+    };
+
+    module(mockModules); // mock all the properties
+
+    this.given = {
+        apiLoaded: function (mockRecaptcha) {
+            mockModules.$window.grecaptcha = mockRecaptcha;
+
+            return _this;
+        },
+        onLoadFunctionName: function (funcName) {
+            module(function (vcRecaptchaServiceProvider) {
+                vcRecaptchaServiceProvider.setOnLoadFunctionName(funcName);
+            });
+            return _this;
+        },
+        mockDocument: function (mockDocument) {
+            mockModules.$document.get = mockDocument.get;
+
+            return _this;
+        }
+    };
+
+    this.when = {
+        created: function () {
+            inject(function (vcRecaptchaService) {
+                _this.service = vcRecaptchaService;
+            })
+        },
+        notifyThatApiLoaded: function () {
+            mockModules.$window.vcRecaptchaApiLoaded();
+            return _this;
+        }
+    };
+}
+
+ServiceDriver.prototype.applyChanges = function () {
+    inject(function ($rootScope) {
+        $rootScope.$digest();
+    });
+};

--- a/tests/service_test.js
+++ b/tests/service_test.js
@@ -117,5 +117,9 @@ describe('service', function () {
         it('should add callback function name to src', function () {
             expect(scriptTagSpy.src).toBe('https://www.google.com/recaptcha/api.js?onload=' + funcName + '&render=explicit');
         });
+
+        it('should validate that recaptcha is loaded', function () {
+            expect(driver.service.reload).toThrowError('reCaptcha has not been loaded yet.');
+        });
     });
 });


### PR DESCRIPTION
No need to load recaptcha script on the html if one of the views uses it.
Load it on demand when vcRecaptchaService is injected in the first time.
closes #175