### PR TITLE
Remove hidden dependency on jQuery

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -135,11 +135,11 @@
                 callback();
             } else {
                 // Generate link on demand
-                var script = $document[0].createElement('script');
+                var script = ng.element('<script/>');
                 script.async = true;
                 script.defer = true;
                 script.src = 'https://www.google.com/recaptcha/api.js?onload='+provider.onLoadFunctionName+'&render=explicit';
-                $document[0].body.appendChild(script);
+                $document.find('body').appendChild(script);
             }
 
             return {

--- a/src/service.js
+++ b/src/service.js
@@ -135,11 +135,11 @@
                 callback();
             } else {
                 // Generate link on demand
-                var script = $document.get(0).createElement('script');
+                var script = $document[0].createElement('script');
                 script.async = true;
                 script.defer = true;
                 script.src = 'https://www.google.com/recaptcha/api.js?onload='+provider.onLoadFunctionName+'&render=explicit';
-                $document.get(0).body.appendChild(script);
+                $document[0].body.appendChild(script);
             }
 
             return {

--- a/tests/service_test.js
+++ b/tests/service_test.js
@@ -93,7 +93,7 @@ describe('service', function () {
             driver
                 .given.onLoadFunctionName(funcName = 'my-func')
                 .given.mockDocument({
-                    get: function () {
+                    find: function () {
                             return {
                                 createElement: function () {
                                     return scriptTagSpy;


### PR DESCRIPTION
jqLite does not have $document.get() method, which creates unnecessary dependency on jQuery being present.
See: https://docs.angularjs.org/api/ng/function/angular.element

Fixes #178