### PR TITLE
Remove include script in <head> of google api

### DIFF
--- a/demo/usage.html
+++ b/demo/usage.html
@@ -8,10 +8,6 @@
 
         <!-- Include AngularJS -->
         <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.28/angular.js"></script>
-
-        <!-- Include the JS ReCaptcha API -->
-        <script src="//www.google.com/recaptcha/api.js?render=explicit&onload=vcRecaptchaApiLoaded" async defer></script>
-
         <!-- Include the ngReCaptcha directive -->
         <script src="./angular-recaptcha.js"></script>
 


### PR DESCRIPTION
Because of Changelog
"3.0.0 - Removed the need to include the Google recaptcha api."