### PR TITLE
recaptcha script could already be in the DOM and not downloaded yet

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -104,7 +104,7 @@
             provider.onLoadFunctionName = onLoadFunctionName;
         };
 
-        provider.$get = ['$rootScope','$window', '$q', '$document', function ($rootScope, $window, $q, $document) {
+        provider.$get = ['$rootScope','$window', '$q', '$document', '$interval', function ($rootScope, $window, $q, $document, $interval) {
             var deferred = $q.defer(), promise = deferred.promise, instances = {}, recaptcha;
 
             $window.vcRecaptchaApiLoadedCallback = $window.vcRecaptchaApiLoadedCallback || [];
@@ -142,6 +142,15 @@
             // Check if grecaptcha is not defined already.
             if (ng.isDefined($window.grecaptcha)) {
                 callback();
+            } else if ($document.find('script[src^="https://www.google.com/recaptcha/api.js"]').length) {
+                console.log('waiting for captcha');
+                // wait for script to be loaded.
+                var intervalWait = $interval(function() {
+                    if (ng.isDefined($window.grecaptcha)) {
+                        $interval.cancel(intervalWait);
+                        callback();
+                    }
+                }, 25);
             } else {
                 // Generate link on demand
                 var script = $window.document.createElement('script');

--- a/src/service.js
+++ b/src/service.js
@@ -142,8 +142,7 @@
             // Check if grecaptcha is not defined already.
             if (ng.isDefined($window.grecaptcha)) {
                 callback();
-            } else if ($document.find('script[src^="https://www.google.com/recaptcha/api.js"]').length) {
-                console.log('waiting for captcha');
+            } else if ($document[0].querySelector('script[src^="https://www.google.com/recaptcha/api.js"]')) {
                 // wait for script to be loaded.
                 var intervalWait = $interval(function() {
                     if (ng.isDefined($window.grecaptcha)) {

--- a/src/service.js
+++ b/src/service.js
@@ -142,7 +142,7 @@
             // Check if grecaptcha is not defined already.
             if (ng.isDefined($window.grecaptcha)) {
                 callback();
-            } else if ($document[0].querySelector('script[src^="https://www.google.com/recaptcha/api.js"]')) {
+            } else if ($window.document.querySelector('script[src^="https://www.google.com/recaptcha/api.js"]')) {
                 // wait for script to be loaded.
                 var intervalWait = $interval(function() {
                     if (ng.isDefined($window.grecaptcha)) {

--- a/tests/service.driver.js
+++ b/tests/service.driver.js
@@ -20,12 +20,8 @@ function ServiceDriver() {
             return _this;
         },
         mockDocument: function (mockDocument) {
-            mockModules.$document.find = mockDocument.find;
-
-            return _this;
-        },
-        mockWindow: function (mockWindow) {
-            mockModules.$window.document = mockWindow.document;
+            mockModules.$document = mockDocument;
+            mockModules.$window.document = mockDocument[0];
 
             return _this;
         }

--- a/tests/service.driver.js
+++ b/tests/service.driver.js
@@ -33,8 +33,9 @@ function ServiceDriver() {
 
     this.when = {
         created: function () {
-            inject(function (vcRecaptchaService) {
+            inject(function (vcRecaptchaService, _$interval_) {
                 _this.service = vcRecaptchaService;
+                _this.$interval = _$interval_;
             })
         },
         notifyThatApiLoaded: function () {

--- a/tests/service_test.js
+++ b/tests/service_test.js
@@ -100,20 +100,21 @@ describe('service', function () {
             createElement = jasmine.createSpy('createElement');
             appendSpy = jasmine.createSpy('appendSpy');
 
+            var doc = [{
+                createElement: createElement,
+                querySelector: function() {
+                    return {};
+                }
+            }];
+            doc.find = function () {
+                return [{
+                    appendChild: appendSpy
+                }];
+            };
+
             driver
                 .given.onLoadFunctionName(funcName = 'my-func')
-                .given.mockDocument({
-                    find: function () {
-                        return [{
-                            appendChild: appendSpy
-                        }]
-                    }
-                })
-                .given.mockWindow({
-                    document: {
-                        createElement: createElement
-                    }
-                })
+                .given.mockDocument(doc)
                 .when.created();
         });
 
@@ -148,27 +149,24 @@ describe('service', function () {
             scriptTagSpy = jasmine.createSpy('scriptTagSpy');
             appendSpy = jasmine.createSpy('appendSpy');
 
+            var doc = [{
+                createElement: function () {
+                    return scriptTagSpy;
+                },
+                querySelector: function() {
+                    return null;
+                }
+            }];
+            doc.find = function () {
+                return [{
+                    appendChild: appendSpy
+                }];
+            };
+
             driver
                 .given.onLoadFunctionName(funcName = 'my-func')
-                .given.mockDocument({
-                    find: function (selector) {
-                        if (selector === 'body') {
-                            return [{
-                                appendChild: appendSpy
-                            }];
-                        }
-                        return [];
-                    }
-                })
-                .given.mockWindow({
-                    document: {
-                        createElement: function () {
-                            return scriptTagSpy;
-                        }
-                    }
-                })
+                .given.mockDocument(doc)
                 .when.created();
-
         });
 
         it('should add script tag to body', function () {


### PR DESCRIPTION
There is a race condition that can happen if google <script> is already in the page when vcRecaptcha is initializing and $window.grecaptcha is not yet defined.

In this case, vcRecaptchaApiLoaded is never called because google recaptcha script takes the first script onLoad callback.

PR is needed to check if google recaptcha script is already in the DOM, and wait for $window.grecaptcha to be defined (when script will be loaded).

My first idea was to parse the script url to override the onLoad call, but onLoad is not mandatory, so we have to wait for the script to load with an interval. Adding script.onload would not work in all browsers.