### PR TITLE
Remove site key length check

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -178,7 +178,7 @@
                     conf.hl = conf.lang || config.lang;
                     conf.badge = conf.badge || config.badge;
 
-                    if (!conf.sitekey || conf.sitekey.length !== 40) {
+                    if (!conf.sitekey) {
                         throwNoKeyException();
                     }
                     return getRecaptcha().then(function (recaptcha) {

--- a/tests/directive_test.js
+++ b/tests/directive_test.js
@@ -36,20 +36,6 @@ describe('directive: vcRecaptcha', function () {
             elementHtml     = '<div vc-recaptcha></div>';
             expectedMessage = 'You need to set the "key" attribute to your public reCaptcha key. If you don\'t have a key, please get one from https://www.google.com/recaptcha/admin/create';
         });
-
-        it('should throw an error - key length is not 40 caracters long', function () {
-            elementHtml     = '<div vc-recaptcha key="key"></div>';
-            expectedMessage = 'You need to set the "key" attribute to your public reCaptcha key. If you don\'t have a key, please get one from https://www.google.com/recaptcha/admin/create';
-
-            $scope.key = 'abc';
-        });
-
-        it('should throw an error - key length is not 40 caracters long - key changed', function () {
-            elementHtml     = '<div vc-recaptcha key="key"></div>';
-            expectedMessage = 'You need to set the "key" attribute to your public reCaptcha key. If you don\'t have a key, please get one from https://www.google.com/recaptcha/admin/create';
-
-            $scope.key = 'abc1';
-        });
     });
 
     describe('widgetId', function () {


### PR DESCRIPTION
Recaptcha may generate site keys with more than 40 characters now, so the length check is outdated and can throw unexpected errors in such cases.