### PR TITLE
Check for grecaptcha.render function availability

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -139,8 +139,8 @@
             }
 
 
-            // Check if grecaptcha is not defined already.
-            if (ng.isDefined($window.grecaptcha)) {
+            // Check if grecaptcha.render is not defined already.
+            if (ng.isFunction(($window.grecaptcha || {}).render)) {
                 callback();
             } else if ($window.document.querySelector('script[src^="https://www.google.com/recaptcha/api.js"]')) {
                 // wait for script to be loaded.

--- a/tests/service_test.js
+++ b/tests/service_test.js
@@ -90,6 +90,35 @@ describe('service', function () {
         });
     });
 
+    // Regresion test for https://git.io/vp2SO
+    describe('without loaded api, loaded grecaptcha from cache without render func', () => {
+        const grecaptchaMock = {};
+        const _key = '1234567890123456789012345678901234567890';
+
+        beforeEach(function () {
+            const doc = [{
+                querySelector: () => ({}),
+            }];
+
+            driver
+                .given.apiLoaded(grecaptchaMock)
+                .given.mockDocument(doc)
+                .when.created();
+        });
+
+        it('should not try to render recaptcha', () => {
+            const spy = jasmine.createSpy('recaptchaCreate');
+
+            driver.service.create('<div></div>', {
+                key: _key,
+                callback: spy
+            });
+
+            expect(() => driver.applyChanges()).not.toThrow();
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
+
     describe('without loaded api, with script tag', function () {
         var createElement,
             appendSpy,


### PR DESCRIPTION
Instead of checking for the variable `grecaptcha` to be defined, now we check for the `grecaptcha.render` function to be defined and to be a function.

It has happened in Firefox(due to browser cache), that sometimes the `grecaptcha` variable is already defined, but as empty object, causing the library to fail due to the lack of the render function.

Fixes #224 